### PR TITLE
Adding CopyContextPropertyWithNullCoalescing component

### DIFF
--- a/Src/CopyContextProperty/BizTalkComponents.PipelineComponents.CopyContextProperty.csproj
+++ b/Src/CopyContextProperty/BizTalkComponents.PipelineComponents.CopyContextProperty.csproj
@@ -61,6 +61,8 @@
     <Compile Include="BiztalkComponents.Utils\PropertyBagHelper.cs" />
     <Compile Include="BiztalkComponents.Utils\RequiredRuntimeAttribute.cs" />
     <Compile Include="BiztalkComponents.Utils\ValidationHelper.cs" />
+    <Compile Include="CopyContextPropertyWithNullCoalescing.cs" />
+    <Compile Include="CopyContextPropertyWithNullCoalescing.Component.cs" />
     <Compile Include="CopyContextProperty.cs" />
     <Compile Include="CopyContextProperty.Component.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Src/CopyContextProperty/CopyContextPropertyWithNullCoalescing.Component.cs
+++ b/Src/CopyContextProperty/CopyContextPropertyWithNullCoalescing.Component.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using BizTalkComponents.Utils;
+using Microsoft.BizTalk.Component.Interop;
+using System.ComponentModel;
+
+namespace BizTalkComponents.PipelineComponents.CopyContextProperty
+{
+    public partial class CopyContextPropertyWithNullCoalescing
+    {
+        public string Name { get { return "Copy Context Property With Null-Coalescing"; } }
+        public string Version { get { return "1.0"; } }
+        public string Description { get { return "Copies one context property applying null coalescing operator on two context properties."; } }
+
+        [Description("Set to True to disable the component.")]
+        public bool Disabled { get; set; }
+
+        public void GetClassID(out Guid classID)
+        {
+            classID = new Guid("4C3DDF79-7FA6-4A2D-B750-8982F549FBE5");
+        }
+
+        public void InitNew()
+        {
+            
+        }
+
+        public IEnumerator Validate(object projectSystem)
+        {
+            return ValidationHelper.Validate(this, false).ToArray().GetEnumerator();
+        }
+
+        public bool Validate(out string errorMessage)
+        {
+            var errors = ValidationHelper.Validate(this, true).ToArray();
+
+            if (errors.Any())
+            {
+                errorMessage = string.Join(",", errors);
+
+                return false;
+            }
+
+            errorMessage = string.Empty;
+
+            return true;
+        }
+
+        public IntPtr Icon { get { return IntPtr.Zero; } }
+
+
+        public void Load(IPropertyBag propertyBag, int errorLog)
+        {
+            var props = this.GetType().GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+            foreach (var prop in props)
+            {
+                if (prop.CanRead & prop.CanWrite)
+                {
+                    object value = PropertyBagHelper.ReadPropertyBag(propertyBag, prop.Name) ?? prop.GetValue(this, null);
+                    prop.SetValue(this, value, null);
+                }
+            }
+        }
+
+        public void Save(IPropertyBag propertyBag, bool clearDirty, bool saveAllProperties)
+        {
+            var props = this.GetType().GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+            foreach (var prop in props)
+            {
+                if (prop.CanRead & prop.CanWrite)
+                {
+                    PropertyBagHelper.WritePropertyBag(propertyBag, prop.Name, prop.GetValue(this,null));
+                }
+            }
+        }
+
+    }
+}

--- a/Src/CopyContextProperty/CopyContextPropertyWithNullCoalescing.cs
+++ b/Src/CopyContextProperty/CopyContextPropertyWithNullCoalescing.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using BizTalkComponents.Utils;
+using Microsoft.BizTalk.Component.Interop;
+using Microsoft.BizTalk.Message.Interop;
+using IComponent = Microsoft.BizTalk.Component.Interop.IComponent;
+
+namespace BizTalkComponents.PipelineComponents.CopyContextProperty
+{
+    [ComponentCategory(CategoryTypes.CATID_PipelineComponent)]
+    [System.Runtime.InteropServices.Guid("98EB6BA0-4FBC-44C5-8A53-A7D37C46A396")]
+    [ComponentCategory(CategoryTypes.CATID_Any)]
+    public partial class CopyContextPropertyWithNullCoalescing : IComponent, IBaseComponent,
+                                        IPersistPropertyBag, IComponentUI
+    {
+        [RequiredRuntime]
+        [DisplayName("First Property Path")]
+        [Description("The property path of the property to copy from.")]
+        [RegularExpression(@"^.*#.*$",
+        ErrorMessage = "A property path should be formatted as namespace#property.")]
+        public string FirstProperty { get; set; }
+
+        [DisplayName("Second Property Path")]
+        [Description("The property path of the property to copy from.")]
+        [RegularExpression(@"^.*#.*$",
+        ErrorMessage = "A property path should be formatted as namespace#property.")]
+        public string SecondProperty { get; set; }
+
+
+        [RequiredRuntime]
+        [DisplayName("Destination Property Path")]
+        [Description("The property path of the property to copy to.")]
+        [RegularExpression(@"^.*#.*$",
+        ErrorMessage = "A property path should be formatted as namespace#property.")]
+        public string DestinationProperty { get; set; }
+
+        public IBaseMessage Execute(IPipelineContext pContext, IBaseMessage pInMsg)
+        {
+            string errorMessage;
+
+            if (!Validate(out errorMessage))
+            {
+                throw new ArgumentException(errorMessage);
+            }
+
+            var firstContextProperty = new ContextProperty(FirstProperty);
+            var secondContextProperty = new ContextProperty(SecondProperty);
+            var destinationContextProperty = new ContextProperty(DestinationProperty);
+            object value1, value2;
+            pInMsg.Context.TryRead(firstContextProperty, out value1);
+            pInMsg.Context.TryRead(secondContextProperty, out value2);
+            if (value1 == null & value2 == null)
+                throw new InvalidOperationException("Could not find the specified properties in BizTalk context.");
+            pInMsg.Context.Promote(destinationContextProperty, value1 ?? value2);
+            return pInMsg;
+        }
+    }
+}

--- a/Tests/UnitTests/BizTalkComponents.CopyContextProperty.Tests.UnitTests.csproj
+++ b/Tests/UnitTests/BizTalkComponents.CopyContextProperty.Tests.UnitTests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BizTalkComponents.CopyContextProperty.Tests.UnitTests</RootNamespace>
     <AssemblyName>BizTalkComponents.CopyContextProperty.Tests.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -18,6 +18,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -60,6 +61,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="CopyContextPropertyWithNullCoalescingTests.cs" />
     <Compile Include="CopyContextPropertyTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Tests/UnitTests/CopyContextPropertyWithNullCoalescingTests.cs
+++ b/Tests/UnitTests/CopyContextPropertyWithNullCoalescingTests.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Winterdom.BizTalk.PipelineTesting;
+
+namespace BizTalkComponents.CopyContextProperty.Tests.UnitTests
+{
+    [TestClass]
+    public class CopyContextPropertyWithNullCoalescingTests
+    {
+        [TestMethod]
+        public void TestCopyPropertyWithNullCoalescing()
+        {
+            var pipeline = PipelineFactory.CreateEmptyReceivePipeline();
+            var component = new PipelineComponents.CopyContextProperty.CopyContextPropertyWithNullCoalescing
+            {
+                FirstProperty= "http://tempuri.org#First",
+                SecondProperty = "http://tempuri.org#Second",
+                DestinationProperty = "http://tempuri.org#Destination"
+            };
+            pipeline.AddComponent(component, PipelineStage.Decode);
+            var message = MessageHelper.Create("<test></test>");
+            message.Context.Promote("Second", "http://tempuri.org", "Second");
+
+            Assert.IsNull(message.Context.Read("First", "http://tempuri.org"));
+
+            var output = pipeline.Execute(message);
+
+            Assert.AreEqual(1, output.Count);
+
+            Assert.IsTrue(output[0].Context.IsPromoted("Destination", "http://tempuri.org"));
+
+        }
+        [TestMethod]
+        public void TestCopyPropertyWithNullCoalescingWhenBothAreNull()
+        {
+            var pipeline = PipelineFactory.CreateEmptyReceivePipeline();
+            var component = new PipelineComponents.CopyContextProperty.CopyContextPropertyWithNullCoalescing
+            {
+                FirstProperty = "http://tempuri.org#First",
+                SecondProperty = "http://tempuri.org#Second",
+                DestinationProperty = "http://tempuri.org#Destination"
+            };
+            pipeline.AddComponent(component, PipelineStage.Decode);
+            var message = MessageHelper.Create("<test></test>");
+
+            Assert.IsNull(message.Context.Read("First", "http://tempuri.org"));
+            Assert.IsNull(message.Context.Read("Second", "http://tempuri.org"));
+            MessageCollection output=null;
+            try
+            {
+                output = pipeline.Execute(message);
+            }
+            catch { }
+            Assert.IsNull(output);
+
+        }
+    }
+}


### PR DESCRIPTION
The new component copies and promotes a context properties from another two properties applying null-coalescing operation between them.